### PR TITLE
Fixed launcher problem and got auto-detection working.

### DIFF
--- a/src/game_fallout4vr_en.ts
+++ b/src/game_fallout4vr_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>GameFallout4VR</name>
     <message>
-        <location filename="gamefallout4vr.cpp" line="81"/>
+        <location filename="gamefallout4vr.cpp" line="127"/>
         <source>Adds support for the game Fallout 4 VR.
 Splash by %1</source>
         <translation type="unfinished"></translation>
@@ -15,6 +15,16 @@ Splash by %1</source>
     <message>
         <location filename="fallout4vrgameplugins.cpp" line="83"/>
         <source>Some of your plugins have invalid names! These plugins can not be loaded by the game. Please see mo_interface.log for a list of affected plugins and rename them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamefallout4vr.cpp" line="52"/>
+        <source>failed to query registry path (preflight): %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gamefallout4vr.cpp" line="59"/>
+        <source>failed to query registry path (read): %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/gamefallout4vr.cpp
+++ b/src/gamefallout4vr.cpp
@@ -30,6 +30,47 @@
 
 using namespace MOBase;
 
+
+// Need to duplicate code from gamegamebryo.cpp here since it's otherwise unaccessible.
+namespace {
+
+std::unique_ptr<BYTE[]> getRegValue(HKEY key, LPCWSTR path, LPCWSTR value,
+                                    DWORD flags, LPDWORD type = nullptr)
+{
+  DWORD size = 0;
+  HKEY subKey;
+  LONG res = ::RegOpenKeyExW(key, path, 0,
+                              KEY_QUERY_VALUE | KEY_WOW64_32KEY, &subKey);
+  if (res != ERROR_SUCCESS) {
+    return std::unique_ptr<BYTE[]>();
+  }
+  res = ::RegGetValueW(subKey, L"", value, flags, type, nullptr, &size);
+  if (res == ERROR_FILE_NOT_FOUND || res == ERROR_UNSUPPORTED_TYPE) {
+    return std::unique_ptr<BYTE[]>();
+  }
+  if (res != ERROR_SUCCESS && res != ERROR_MORE_DATA) {
+    throw MOBase::MyException(QObject::tr("failed to query registry path (preflight): %1").arg(res, 0, 16));
+  }
+
+  std::unique_ptr<BYTE[]> result(new BYTE[size]);
+  res = ::RegGetValueW(subKey, L"", value, flags, type, result.get(), &size);
+
+  if (res != ERROR_SUCCESS) {
+    throw MOBase::MyException(QObject::tr("failed to query registry path (read): %1").arg(res, 0, 16));
+  }
+
+  return result;
+}
+
+QString findInRegistry(HKEY baseKey, LPCWSTR path, LPCWSTR value)
+{
+  std::unique_ptr<BYTE[]> buffer = getRegValue(baseKey, path, value, RRF_RT_REG_SZ | RRF_NOEXPAND);
+
+  return QString::fromUtf16(reinterpret_cast<const ushort*>(buffer.get()));
+}
+
+}
+
 GameFallout4VR::GameFallout4VR()
 {
 }
@@ -39,6 +80,11 @@ bool GameFallout4VR::init(IOrganizer *moInfo)
   if (!GameGamebryo::init(moInfo)) {
     return false;
   }
+
+  // GameGamebryo::init() searches for the wrong registry key when setting the game path,
+  // and we cannot just override it because the corresponding code is in a private non-virtual function.
+  // So we need to set the correct path AFTER we have called GameGamebryo::init().
+  setGamePath(identifyGamePathVR());
 
   registerFeature<ScriptExtender>(new Fallout4VRScriptExtender(this));
   registerFeature<DataArchives>(new Fallout4VRDataArchives(myGamesPath()));
@@ -220,4 +266,11 @@ int GameFallout4VR::nexusGameID() const
 QString GameFallout4VR::getLauncherName() const
 {
   return binaryName(); // Fallout 4 VR has no Launcher, so we just return the name of the game binary
+}
+
+QString GameFallout4VR::identifyGamePathVR() const
+{
+  // In every other Bethesda game they use gameShortName() as registry key, but for Fallout 4 VR they use gameName()
+  QString path = "Software\\Bethesda Softworks\\" + gameName();
+  return findInRegistry(HKEY_LOCAL_MACHINE, path.toStdWString().c_str(), L"Installed Path");
 }

--- a/src/gamefallout4vr.cpp
+++ b/src/gamefallout4vr.cpp
@@ -216,3 +216,8 @@ int GameFallout4VR::nexusGameID() const
 {
   return 1151;
 }
+
+QString GameFallout4VR::getLauncherName() const
+{
+  return binaryName(); // Fallout 4 VR has no Launcher, so we just return the name of the game binary
+}

--- a/src/gamefallout4vr.h
+++ b/src/gamefallout4vr.h
@@ -48,6 +48,10 @@ public: // IPlugin interface
   virtual bool isActive() const override;
   virtual QList<MOBase::PluginSetting> settings() const override;
 
+private:
+
+  QString identifyGamePathVR() const;
+
 };
 
 #endif // GAMEFallout4VR_H

--- a/src/gamefallout4vr.h
+++ b/src/gamefallout4vr.h
@@ -37,6 +37,7 @@ public: // IPluginGame interface
   virtual LoadOrderMechanism loadOrderMechanism() const override;
   virtual int nexusModOrganizerID() const override;
   virtual int nexusGameID() const override;
+  virtual QString getLauncherName() const override;
 
 public: // IPlugin interface
 


### PR DESCRIPTION
Fixed Launcher problem, MO does not expect a Fallout4VRLauncher.exe in the install dir anymore.
Also got auto-detection of an existing Fallout 4 VR installation working.